### PR TITLE
fix API key references

### DIFF
--- a/.github/workflows/cypress.yaml
+++ b/.github/workflows/cypress.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Install NPM dependencies, cache them correctly
       # and run all Cypress tests
@@ -28,4 +28,4 @@ jobs:
       - name: Run tests
         run: yarn test:cypress
         env:
-          REPLAY_API_KEY: ${{ secrets.REPLAY_API_KEY }}
+          REPLAY_API_KEY: ${{ secrets.CYPRESS_REPLAY_API_KEY }}

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Run Playwright tests
       run: yarn test:playwright
       env:
-          PLAYWRIGHT_REPLAY_API_KEY: ${{ secrets.PLAYWRIGHT_REPLAY_API_KEY }}
+          REPLAY_API_KEY: ${{ secrets.PLAYWRIGHT_REPLAY_API_KEY }}
           REPLAY_PLAYWRIGHT_FIXTURE: ${{ secrets.REPLAY_PLAYWRIGHT_FIXTURE }}
     - uses: actions/upload-artifact@v4
       if: always()


### PR DESCRIPTION
looks like this was simply a typo on the references to API key. at some point it would be nice if we had more informative messages. right now it just says this:

```
site:test:cypress: [replay.io]: ❌ We encountered some unexpected errors processing your recordings and was unable to upload them.
site:test:cypress: [replay.io]:    - Upload failed
site:test:cypress: [replay.io]:    - Upload failed
```